### PR TITLE
Don't use magic accessor for class properties

### DIFF
--- a/src/Component/flashMessages.latte
+++ b/src/Component/flashMessages.latte
@@ -1,7 +1,7 @@
 {snippet}
 {foreach $flashes as $flash}
-	<div class='{isset($typeClasses[$flash->type]) ? $typeClasses[$flash->type] : $typeClasses[NULL]}'>
-		{$flash->message}
+	<div class='{isset($typeClasses[$flash->getType()]) ? $typeClasses[$flash->getType()] : $typeClasses[NULL]}'>
+		{$flash->getMessage()}
 	</div>
 {/foreach}
 {/snippet}


### PR DESCRIPTION
It is deprecated in Nette\SmartObject